### PR TITLE
fix(server ip): allow Win10/Docker Desktop for Windows to use localhost for Server IP

### DIFF
--- a/application/src/private.js
+++ b/application/src/private.js
@@ -1,3 +1,12 @@
-const windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
+var windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
+
+// Win 10/Docker Desktop for Windows uses localhost
+// Win10 has a platform of Win32 - so need an additional check
+// on the appVersion to avoid matching the platform
+const win10 = RegExp("Windows NT 10.0*");
+
+if (win10.test(window.navigator.appVersion)) {
+    windowsPlatforms = [];
+}
 
 export const SERVER_IP = windowsPlatforms.indexOf(window.navigator.platform) < 0 ? 'http://localhost:4000' : 'http://192.168.99.100:4000';


### PR DESCRIPTION

Add check on Win10 using appVersion. If found, clear windowsPlatforms to
allow Win10 to use localhost.