### PR TITLE
Fix log out to navigate to main page / clear login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
-# React-Docker Test Environment
+# Shift3 React Challenge Project
+This project represents a challenge to test your git flow, programming, and troubleshooting fundamentals. Below you will find instructions on how to complete the challenge, as well as additional information on how to stand up and navigate this project.
+
+## Challenge Instructions
+You will begin by creating a fork of this repository to your own Github account. All work will be completed and reviewed within your own fork. Please do not create a Pull Request (PR) back into this repository.
+
+Once you have created your fork, review the Issues labeled `challenge task` [HERE](https://github.com/Shift3/react-challenge-project/issues?q=is%3Aissue+is%3Aopen+label%3A%22challenge+task%22). Work on each task in a new branch. Once the work is completed, create a Pull Request from the working branch to your `master` branch and reference the Issue you are working on. These open PRs will be the final submission which Shift3 will review.
+
+Once you are ready to submit your work, send an email to your Shift3 contact with a link to your fork.
+
+Please apply the following Shift3 Standard Practices as you work on this project:
+- Each unit of work (Issue) should be completed within its own [branch](https://github.com/Shift3/standards-and-practices/blob/master/standards/branching.md).
+- Use Karma-style formatting for your [Git Commit Messages](https://github.com/Shift3/standards-and-practices/blob/master/standards/commits.md).
+- Generate a PR for each unit of work (Issue) which is completed. Keep the scope of these PRs as narrow as possible. Try not to create PRs which rely on or contain code from previous PRs unless there is truly a dependency between the two units of work.
+
+## Project Information
 
 This is a multi-container docker environment that utilizes Docker to create three seperate but linked containers:
 

--- a/application/src/components/nav/nav.js
+++ b/application/src/components/nav/nav.js
@@ -15,7 +15,7 @@ const Nav = (props) => {
                     <label className="nav-label">View Orders</label>
                 </div>
             </Link>
-            <Link to={"/login"} className="nav-link">
+            <Link to={"/"} className="nav-link">
                 <div className="nav-link-style">
                     <label className="nav-label">Log Out</label>
                 </div>

--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,9 +5,9 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
-            return { ...state, ...INITIAL_STATE }
+            return {};
         default:
             return state;
     }


### PR DESCRIPTION
In authReducer, clearing the state.  In nav, changing the link to go to / rather than /login
[This includes the fix from #17 which was needed for testing]
[This also includes private.js which it shouldnt - but its in my copy of dev and not my copy of master so it will show up in every PR for each fix and feature]